### PR TITLE
removing parent modules closes #55

### DIFF
--- a/src/modules.test.ts
+++ b/src/modules.test.ts
@@ -40,4 +40,10 @@ describe('when running lint', () => {
       expect(results[6].config.rules['packagejson-same-name']).toBeFalsy();
     }
   });
+
+  it('modules that have other modules inside its path hierarchy should be ignored', async () => {
+    const results = discoverModules(baseDir, baseConfig, '.monolint.json');
+    expect(results).toHaveLength(7);
+  });
+
 });

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -70,9 +70,27 @@ const discoverModules = (baseDir: string, baseConfig: Config, configFileName: st
     });
   }
 
+  // remove modules that aren't leaves (they have other modules inside them #55)
+  const fmodules: Module[] = [];
+  for (let aa = 0; aa < modules.length; aa += 1) {
+    const candidateModule = modules[aa];
+    let foundParent = false;
+    for (let bb = 0; bb < modules.length; bb += 1) {
+      const otherModule = modules[bb];
+      if (otherModule.path !== candidateModule.path &&
+        otherModule.path.startsWith(candidateModule.path)) {
+        foundParent = true;
+        break;
+      }
+    }
+    if (!foundParent) {
+      fmodules.push(candidateModule);
+    }
+  }
+
   // sort by module name ascending to make it previsible and easier to create
   // newer modules for tests without breaking existing tests and to debug in general
-  modules.sort((aa, bb) => {
+  fmodules.sort((aa, bb) => {
     if (bb.name > aa.name) {
       return -1;
     }
@@ -89,7 +107,7 @@ const discoverModules = (baseDir: string, baseConfig: Config, configFileName: st
     return 0;
   });
 
-  return modules;
+  return fmodules;
 };
 
 export { discoverModules };

--- a/src/rules/test-cases/general/modules/group1/package.json
+++ b/src/rules/test-cases/general/modules/group1/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "test-base-should-not-be-module"
+}


### PR DESCRIPTION
**Summary**
Discovered modules that have other modules inside should be ignored. package.json at the root of a monorepo based on yarn or npm normally contains a package.json that doesn't define by itself a module.

**Closing issues**

fixes #55 